### PR TITLE
Fix linspace interface

### DIFF
--- a/ecpy/tasks/tasks/logic/loop_linspace_interface.py
+++ b/ecpy/tasks/tasks/logic/loop_linspace_interface.py
@@ -89,14 +89,14 @@ class LinspaceLoopInterface(TaskInterface):
         # Update stop to make sure that the generated step is close to the user
         # specified one.
         stop_digit = abs(Decimal(str(stop)).as_tuple().exponent)
-        stop = round(start + (num-1)*step, stop_digit)
+        start_digit = abs(Decimal(str(start)).as_tuple().exponent)
+        step_digit = abs(Decimal(str(step)).as_tuple().exponent)
+        digit = max((start_digit, step_digit, stop_digit))
+        stop = round(start + (num-1)*step, digit)
 
         # Round values to the maximal number of digit used in start, stop and
         # step so that we never get issues with floating point rounding issues.
         # The max is used to allow from 1.01 to 2.01 by 0.1
-        start_digit = abs(Decimal(str(start)).as_tuple().exponent)
-        step_digit = abs(Decimal(str(step)).as_tuple().exponent)
-        digit = max((start_digit, step_digit, stop_digit))
         raw_values = np.linspace(start, stop, num)
         iterable = np.fromiter((round(value, digit)
                                 for value in raw_values),

--- a/tests/tasks/tasks/logic/test_loop_task.py
+++ b/tests/tasks/tasks/logic/test_loop_task.py
@@ -88,7 +88,7 @@ def test_linspace_handling_of_step_sign(monkeypatch, linspace_interface):
     expected = np.array([3.0, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0]
                         )
     np.testing.assert_array_equal(lt.database_entries['iterable'],
-                                         expected)
+                                  expected)
 
 
 def test_linspace_handling_of_rounding(monkeypatch, linspace_interface):
@@ -123,8 +123,14 @@ def test_linspace_handling_of_rounding(monkeypatch, linspace_interface):
                          1.91, 2.01])
     np.testing.assert_array_equal(lt.database_entries['iterable'], expected)
 
-    # the stop case seems pretty redundant with either start or stop, so no
-    # test
+    # Start use more digit and stop does not round properly
+    lt.interface = linspace_interface
+    linspace_interface.start = '0.501'
+    linspace_interface.stop = '1'
+    linspace_interface.step = '0.2'
+    linspace_interface.perform()
+    expected = np.array([0.501, 0.701, 0.901])
+    np.testing.assert_array_equal(lt.database_entries['iterable'], expected)
 
 
 def test_linspace_handling_of_non_matching_stop(monkeypatch,

--- a/tests/tasks/tasks/logic/test_loop_task.py
+++ b/tests/tasks/tasks/logic/test_loop_task.py
@@ -68,7 +68,7 @@ def false_perform_loop(self, iterable):
 
 
 def test_linspace_handling_of_step_sign(monkeypatch, linspace_interface):
-    """Test that no matter the sign of step we generat the proper array.
+    """Test that no matter the sign of step we generate the proper array.
 
     """
     monkeypatch.setattr(LoopTask, 'perform_loop', false_perform_loop)
@@ -79,13 +79,72 @@ def test_linspace_handling_of_step_sign(monkeypatch, linspace_interface):
     lt.interface = linspace_interface
     linspace_interface.step = '-0.1'
     linspace_interface.perform()
-    np.testing.assert_array_almost_equal(lt.database_entries['iterable'],
-                                         np.linspace(1, 2, 11))
+    expected = np.array([1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
+                        )
+    np.testing.assert_array_equal(lt.database_entries['iterable'], expected)
 
-    linspace_interface.start = '5.0'
+    linspace_interface.start = '3.0'
     linspace_interface.perform()
-    np.testing.assert_array_almost_equal(lt.database_entries['iterable'],
-                                         np.linspace(5, 2, 31))
+    expected = np.array([3.0, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0]
+                        )
+    np.testing.assert_array_equal(lt.database_entries['iterable'],
+                                         expected)
+
+
+def test_linspace_handling_of_rounding(monkeypatch, linspace_interface):
+    """Test that we properly round the values.
+
+    """
+    monkeypatch.setattr(LoopTask, 'perform_loop', false_perform_loop)
+    root = RootTask(should_stop=Event(), should_pause=Event())
+    lt = LoopTask(name='Test')
+    root.add_child_task(0, lt)
+
+    # Step use more digit
+    lt.interface = linspace_interface
+    linspace_interface.start = '0.1'
+    linspace_interface.stop = '0.11'
+    linspace_interface.step = '0.001'
+    linspace_interface.perform()
+    expected = np.array([0.1, 0.101, 0.102, 0.103, 0.104, 0.105, 0.106,
+                         0.107, 0.108, 0.109, 0.11])
+    # Check that this does indeed cause a rounding issue
+    with pytest.raises(AssertionError):
+        np.testing.assert_array_equal(np.linspace(0.1, 0.11, 11), expected)
+    np.testing.assert_array_equal(lt.database_entries['iterable'], expected)
+
+    # Start use more digit
+    lt.interface = linspace_interface
+    linspace_interface.start = '1.01'
+    linspace_interface.stop = '2.01'
+    linspace_interface.step = '0.1'
+    linspace_interface.perform()
+    expected = np.array([1.01, 1.11, 1.21, 1.31, 1.41, 1.51, 1.61, 1.71, 1.81,
+                         1.91, 2.01])
+    np.testing.assert_array_equal(lt.database_entries['iterable'], expected)
+
+    # the stop case seems pretty redundant with either start or stop, so no
+    # test
+
+
+def test_linspace_handling_of_non_matching_stop(monkeypatch,
+                                                linspace_interface):
+    """Test that we respect the step even if stop does not match.
+
+    """
+    monkeypatch.setattr(LoopTask, 'perform_loop', false_perform_loop)
+    root = RootTask(should_stop=Event(), should_pause=Event())
+    lt = LoopTask(name='Test')
+    root.add_child_task(0, lt)
+
+    lt.interface = linspace_interface
+    linspace_interface.start = '0.1'
+    linspace_interface.stop = '0.1101'
+    linspace_interface.step = '0.001'
+    linspace_interface.perform()
+    expected = np.array([0.1, 0.101, 0.102, 0.103, 0.104, 0.105, 0.106,
+                         0.107, 0.108, 0.109, 0.11])
+    np.testing.assert_array_equal(lt.database_entries['iterable'], expected)
 
 
 class TestLoopTask(object):


### PR DESCRIPTION
This should fix the issue of sometime missed end point while preserving the rounding properties and handling of stop not fitting the step. Actually I added some test for that. I am still concerned with floating point rounding issues so if anybody has some ideas about how to test for more of those I am taking.