### PR TITLE
app : allow dep_type to be absent when analysing

### DIFF
--- a/ecpy/app/dependencies/plugin.py
+++ b/ecpy/app/dependencies/plugin.py
@@ -165,7 +165,7 @@ class DependenciesPlugin(Plugin):
         # and create the generator traversing the object.
         if isinstance(obj, Section):
             gen = traverse_config(obj)
-            getter = getitem
+            getter = dict.get
         else:
             gen = obj.traverse()
             getter = getattr
@@ -182,7 +182,9 @@ class DependenciesPlugin(Plugin):
         need_runtime = 'runtime' in dependencies
 
         for component in gen:
-            dep_type = getter(component, 'dep_type')
+            dep_type = getter(component, 'dep_type', None)
+            if dep_type is None:
+                continue
             try:
                 collector = builds[dep_type]
             except KeyError:

--- a/tests/app/dependencies/test_plugin.py
+++ b/tests/app/dependencies/test_plugin.py
@@ -119,9 +119,11 @@ def test_analysing_build_from_config(dep_workbench):
 
     """
     core = dep_workbench.get_plugin('enaml.workbench.core')
+    # nested field ensures that we skip object missing a dep_type
     dep = core.invoke_command(ANALYSE,
                               {'obj': ConfigObj({'val': '1',
-                                                 'dep_type': 'test'})}
+                                                 'dep_type': 'test',
+                                                 'nested': {}})}
                               )
     assert not dep.errors
     assert 'test' in dep.dependencies


### PR DESCRIPTION
This allows to skip preferences for object that are rebuilt internally.