### PR TITLE
Fix collections of instr dependencies of interfaces

### DIFF
--- a/docs/source/dev_guide/tasks.rst
+++ b/docs/source/dev_guide/tasks.rst
@@ -321,7 +321,9 @@ but only two of them must be given non-default values :
   attribute, the supported driver should be listed. Note that if a driver is
   supported through the use of an interface the driver should be listed in the
   interface and not in the task. Driver should be listed by specifying their id
-  ie top_package.architecture.class_name.
+  ie top_package.architecture.class_name. If this field is specified, the task
+  should be a subclass of |InstrumentTask| or have a selected_instrument member
+  similar to the one of |InstrumentTask|.
 - 'dependencies' : If the task has rutime dependencies other than instruments
   the ids of the corresponding analysers should be listed here.
 
@@ -504,7 +506,9 @@ example :
 .. note::
 
     |Interface|, like |Task| has a *metadata* and an *instruments* members
-    which have the exact same functionalities.
+    which have the exact same functionalities.  If *instruments* is specified,
+    the interface should have a selected_instrument member similar to the one
+    of |InstrumentTask| or be linked to an interface/task that does.
 
 
 .. _dev_tasks_new_filter:

--- a/ecpy/tasks/infos.py
+++ b/ecpy/tasks/infos.py
@@ -12,7 +12,8 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
-from atom.api import Atom, List, Subclass, Dict, Coerced, Typed
+from atom.api import (Atom, List, Subclass, Dict, Coerced, Typed, Unicode,
+                      set_default)
 import enaml
 
 from .tasks.base_tasks import BaseTask
@@ -24,15 +25,28 @@ with enaml.imports():
     from .configs.base_config_views import BaseConfigView
 
 
-INSTR_RUNTIME_DRIVERS_ID = 'ecpy.tasks.instruments.drivers'
+INSTR_RUNTIME_TASK_DRIVERS_ID = 'ecpy.tasks.instruments.drivers'
 
-INSTR_RUNTIME_PROFILES_ID = 'ecpy.tasks.instruments.profiles'
+INSTR_RUNTIME_TASK_PROFILES_ID = 'ecpy.tasks.instruments.profiles'
+
+INSTR_RUNTIME_INTERFACE_DRIVERS_ID = 'ecpy.tasks.interface.instruments.drivers'
+
+INSTR_RUNTIME_INTERFACE_PROFILES_ID =\
+    'ecpy.tasks.interface.instruments.profiles'
 
 
 class ObjectDependentInfos(Atom):
     """Base infos for tasks and interfaces.
 
     """
+    #: Id of the runtime dependency analyser to use for driver detection to add
+    #: to the dependencies if instruments is set.
+    DRIVER_ANALYSER = Unicode()
+
+    #: Id of the runtime dependency analyser to use for profile detection to
+    #: add to the dependencies if instruments is set.
+    PROFILE_ANALYSER = Unicode()
+
     #: Set of instrument supported by this task. This should never be updated
     #: in place, it should always be copied and replaced by the new value.
     instruments = Coerced(set, ())
@@ -69,11 +83,11 @@ class ObjectDependentInfos(Atom):
 
         """
         if new:
-            self.dependencies |= set((INSTR_RUNTIME_DRIVERS_ID,
-                                      INSTR_RUNTIME_PROFILES_ID))
+            self.dependencies |= set((self.DRIVER_ANALYSER,
+                                      self.PROFILE_ANALYSER))
         else:
-            self.dependencies -= set((INSTR_RUNTIME_DRIVERS_ID,
-                                      INSTR_RUNTIME_PROFILES_ID))
+            self.dependencies -= set((self.DRIVER_ANALYSER,
+                                      self.PROFILE_ANALYSER))
 
 
 class TaskInfos(ObjectDependentInfos):
@@ -90,6 +104,10 @@ class TaskInfos(ObjectDependentInfos):
     #: etc
     metadata = Dict()
 
+    DRIVER_ANALYSER = set_default(INSTR_RUNTIME_TASK_DRIVERS_ID)
+
+    PROFILE_ANALYSER = set_default(INSTR_RUNTIME_TASK_PROFILES_ID)
+
 
 class InterfaceInfos(ObjectDependentInfos):
     """An object used to store informations about an interface.
@@ -103,6 +121,10 @@ class InterfaceInfos(ObjectDependentInfos):
 
     #: Parent task or interface infos.
     parent = Typed(ObjectDependentInfos)
+
+    DRIVER_ANALYSER = set_default(INSTR_RUNTIME_INTERFACE_DRIVERS_ID)
+
+    PROFILE_ANALYSER = set_default(INSTR_RUNTIME_INTERFACE_PROFILES_ID)
 
 
 class ConfigInfos(Atom):

--- a/ecpy/tasks/manifest.enaml
+++ b/ecpy/tasks/manifest.enaml
@@ -484,6 +484,24 @@ enamldef TasksManagerManifest(PluginManifest):
             analyse => (workbench, obj, dependencies, errors):
                 dependencies.add(obj.selected_instrument[1])
 
+        RuntimeDependencyAnalyser:
+            id = 'ecpy.tasks.interface.instruments.profiles'
+            collector_id = 'ecpy.instruments.profiles'
+            analyse => (workbench, obj, dependencies, errors):
+                if not hasattr(obj, 'selected_instrument'):
+                    obj = obj.task
+                dependencies.add(obj.selected_instrument[0])
+
+        RuntimeDependencyAnalyser:
+            id = 'ecpy.tasks.interface.instruments.drivers'
+            collector_id = 'ecpy.instruments.drivers'
+            analyse => (workbench, obj, dependencies, errors):
+                if not hasattr(obj, 'selected_instrument'):
+                    from .tasks.task_interface import IInterface
+                    obj = (obj.parent if isinstance(obj, IInterface) else
+                           obj.task)
+                dependencies.add(obj.selected_instrument[1])
+
     Extension:
         id = 'prefs'
         point = 'ecpy.app.preferences.plugin'

--- a/tests/tasks/test_plugin.py
+++ b/tests/tasks/test_plugin.py
@@ -191,7 +191,7 @@ def test_get_interface_infos(task_workbench):
 
 
 def test_get_interface(task_workbench):
-    """Test accessing a task.
+    """Test accessing an interface.
 
     """
     core = task_workbench.get_plugin('enaml.workbench.core')
@@ -207,7 +207,7 @@ def test_get_interface(task_workbench):
 
 
 def test_get_interfaces(task_workbench):
-    """Test accessing multiple tasks.
+    """Test accessing multiple interfaces.
 
     """
     core = task_workbench.get_plugin('enaml.workbench.core')


### PR DESCRIPTION
In order to allow instrument task that always requires an interface, a bad change was made some time ago. This fixes the introduced issue by adding dedicated analysers for runtime dependencies for interfaces. Tests have also been added.

@leghtas this should fix your issue could you please review (and test locally) ?