### PR TITLE
Use surrogate escape on Python 2 when decoding formatted traceback

### DIFF
--- a/ecpy/__main__.py
+++ b/ecpy/__main__.py
@@ -16,13 +16,13 @@ import sys
 import threading
 from pkg_resources import iter_entry_points
 from operator import itemgetter
-from traceback import format_exc
 from argparse import ArgumentParser
 
 import enaml
 from atom.api import Atom, Dict, Value, List
 from enaml.qt.qt_application import QtApplication
 from enaml.workbench.api import Workbench
+from ecpy.utils.traceback import format_exc
 
 with enaml.imports():
     from enaml.stdlib.message_box import MessageBox, DialogButton

--- a/ecpy/app/dependencies/plugin.py
+++ b/ecpy/app/dependencies/plugin.py
@@ -14,12 +14,12 @@ from __future__ import (division, unicode_literals, print_function,
 
 from operator import getitem
 from collections import defaultdict
-from traceback import format_exc
 
 from configobj import Section
 from atom.api import Atom, Typed
 from enaml.workbench.api import Plugin
 
+from ...utils.traceback import format_exc
 from ...utils.configobj_ops import traverse_config
 from ...utils.plugin_tools import ExtensionsCollector, make_extension_validator
 

--- a/ecpy/app/errors/manifest.enaml
+++ b/ecpy/app/errors/manifest.enaml
@@ -14,7 +14,6 @@ from __future__ import (division, unicode_literals, print_function,
 
 import logging
 from pprint import pformat
-from traceback import format_exc
 from collections import defaultdict, Mapping
 
 from enaml.workbench.api import PluginManifest, ExtensionPoint, Extension
@@ -25,6 +24,7 @@ from enaml.widgets.api import MultilineField
 from .errors import ErrorHandler
 from ..states.state import State
 from .widgets import BasicErrorsDisplay, HierarchicalErrorsDisplay
+from ...utils.traceback import format_exc
 from ...utils.mapping_utils import recursive_update
 from ...utils.plugin_tools import make_handler
 

--- a/ecpy/app/errors/plugin.py
+++ b/ecpy/app/errors/plugin.py
@@ -16,7 +16,6 @@ import logging
 from collections import defaultdict
 from inspect import cleandoc
 from pprint import pformat
-from traceback import format_exc, format_tb
 from textwrap import fill
 
 import enaml
@@ -25,6 +24,7 @@ from enaml.workbench.api import Plugin
 from enaml.application import deferred_call
 
 from .errors import ErrorHandler
+from ...utils.traceback import format_exc, format_tb
 from ...utils.plugin_tools import ExtensionsCollector, make_extension_validator
 
 with enaml.imports():

--- a/ecpy/app/icons/plugin.py
+++ b/ecpy/app/icons/plugin.py
@@ -13,11 +13,11 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 import logging
-from traceback import format_exc
 
 from atom.api import List, Typed, Unicode
 
 from .icon_theme import IconTheme, IconThemeExtension
+from ...utils.traceback import format_exc
 from ...utils.plugin_tools import (HasPreferencesPlugin, ExtensionsCollector,
                                    make_extension_validator)
 

--- a/ecpy/app/packages/manifest.enaml
+++ b/ecpy/app/packages/manifest.enaml
@@ -22,7 +22,6 @@ from __future__ import (division, unicode_literals, print_function,
 
 import logging
 from collections import Mapping
-from traceback import format_exc
 from pprint import pformat
 
 from enaml.workbench.api import PluginManifest, Extension
@@ -31,6 +30,7 @@ from enaml.widgets.api import MultilineField
 from ..app_extensions import AppStartup
 from ..errors.errors import ErrorHandler
 from ..errors.widgets import BasicErrorsDisplay
+from ...utils.traceback import format_exc
 
 PLUGIN_ID = 'ecpy.app.packages'
 logger = logging.getLogger(__name__)

--- a/ecpy/app/packages/plugin.py
+++ b/ecpy/app/packages/plugin.py
@@ -14,10 +14,11 @@ from __future__ import (division, unicode_literals, print_function,
 
 import pkg_resources
 import logging
-from traceback import format_exc
+
 from atom.api import List, Dict
 from enaml.workbench.api import Plugin, PluginManifest
 
+from ...utils.traceback import format_exc
 
 logger = logging.getLogger(__name__)
 

--- a/ecpy/instruments/drivers/driver_decl.py
+++ b/ecpy/instruments/drivers/driver_decl.py
@@ -12,12 +12,11 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
-from traceback import format_exc
-
 from atom.api import Unicode, Dict, Property, Enum
 from enaml.core.api import d_
 from future.utils import python_2_unicode_compatible
 
+from ...utils.traceback import format_exc
 from ...utils.declarator import Declarator, GroupDeclarator, import_and_get
 from ..infos import DriverInfos, INSTRUMENT_KINDS
 

--- a/ecpy/instruments/widgets/profile_edition.enaml
+++ b/ecpy/instruments/widgets/profile_edition.enaml
@@ -12,8 +12,6 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
-from traceback import format_exc
-
 from atom.api import Coerced, Bool
 from enaml.validator import Validator
 from enaml.layout.api import hbox, vbox, spacer, Pos
@@ -23,6 +21,7 @@ from enaml.widgets.api import (Notebook, Page, Label, Field, PushButton,
                                PopupView, Container, Menu, Action,
                                Window)
 
+from ...utils.traceback import format_exc
 from ...utils.widgets.qt_list_str_widget import QtListStrWidget
 from ...utils.transformers import ids_to_unique_names
 from ...utils.enaml_destroy_hook import add_destroy_hook

--- a/ecpy/measure/engines/process_engine/engine.py
+++ b/ecpy/measure/engines/process_engine/engine.py
@@ -16,11 +16,11 @@ import logging
 from multiprocessing import Pipe, Queue, Event
 from threading import Thread
 from threading import Event as tEvent
-from traceback import format_exc
 from pprint import pformat
 
 from atom.api import Typed, Value, Bool
 
+from ....utils.traceback import format_exc
 from ....app.log.tools import QueueLoggerThread
 from ..base_engine import BaseEngine
 from ..utils import ThreadMeasureMonitor

--- a/ecpy/measure/engines/process_engine/subprocess.py
+++ b/ecpy/measure/engines/process_engine/subprocess.py
@@ -16,10 +16,10 @@ import os
 import logging
 import logging.config
 import sys
-from traceback import format_exc
 from multiprocessing import Process
 from time import sleep
 
+from ....utils.traceback import format_exc
 from ....app.log.tools import (StreamToLogRedirector, DayRotatingTimeHandler)
 from ....tasks.api import build_task_from_config
 from ..utils import MeasureSpy

--- a/ecpy/measure/engines/utils.py
+++ b/ecpy/measure/engines/utils.py
@@ -16,11 +16,11 @@ import logging
 from threading import Thread
 from queue import Empty  # This is allowed thanks to the future package
 from multiprocessing.queues import Queue
-from traceback import format_exc
 from pickle import dumps
 
 from atom.api import Atom, Coerced, Typed
 
+from ...utils.traceback import format_exc
 from ...tasks.tasks.database import TaskDatabase
 
 

--- a/ecpy/measure/measure.py
+++ b/ecpy/measure/measure.py
@@ -14,7 +14,6 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 import logging
-from traceback import format_exc
 from collections import OrderedDict, defaultdict
 from itertools import chain
 from datetime import date
@@ -25,6 +24,7 @@ from atom.api import (Atom, Dict, Unicode, Typed, ForwardTyped, Bool, Enum,
 from configobj import ConfigObj
 
 from ..tasks.api import RootTask
+from ..utils.traceback import format_exc
 from ..utils.configobj_ops import include_configobj
 from ..utils.atom_util import HasPrefAtom
 

--- a/ecpy/measure/monitors/text_monitor/rules/base.py
+++ b/ecpy/measure/monitors/text_monitor/rules/base.py
@@ -14,12 +14,12 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 from inspect import cleandoc
-from traceback import format_exc
 
 from future.utils import python_2_unicode_compatible
 from atom.api import Unicode, List, Dict
 from enaml.core.api import Declarative, d_
 
+from .....utils.traceback import format_exc
 from .....utils.atom_util import HasPrefAtom
 from .....utils.declarator import (Declarator, GroupDeclarator,
                                    import_and_get)

--- a/ecpy/measure/processor.py
+++ b/ecpy/measure/processor.py
@@ -19,7 +19,6 @@ from __future__ import (division, unicode_literals, print_function,
 import os
 import logging
 from time import sleep
-from traceback import format_exc
 from threading import Thread, RLock
 
 import enaml
@@ -31,6 +30,7 @@ from enaml.application import deferred_call, schedule
 from .engines.api import BaseEngine, ExecutionInfos
 from .measure import Measure
 from ..utils.flags import BitFlag
+from ..utils.traceback import format_exc
 
 
 logger = logging.getLogger(__name__)

--- a/ecpy/measure/workspace/measure_edition.enaml
+++ b/ecpy/measure/workspace/measure_edition.enaml
@@ -14,7 +14,6 @@ from __future__ import (division, unicode_literals, print_function,
 
 import logging
 from operator import attrgetter
-from traceback import format_exc
 from textwrap import fill
 from inspect import cleandoc
 
@@ -25,6 +24,7 @@ from enaml.widgets.api import (PushButton, Menu, Action, Container, Dialog,
                                Label, Field, Notebook, DockItem, DockArea)
 from enaml.stdlib.message_box import question
 
+from ...utils.traceback import format_exc
 from ...utils.widgets.qt_clipboard import CLIPBOARD
 from ...utils.widgets.qt_tree_widget import QtTreeWidget
 from ...utils.widgets.tree_nodes import TreeNode

--- a/ecpy/measure/workspace/tools_edition.enaml
+++ b/ecpy/measure/workspace/tools_edition.enaml
@@ -12,13 +12,12 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
-from traceback import format_exc
-
 from enaml.widgets.api import (DockItem, Notebook, Page, Dialog, PushButton,
                                Container, MultilineField, Label)
 from enaml.layout.api import hbox, vbox, spacer
 from enaml.core.api import Declarative, Include
 
+from ...utils.traceback import format_exc
 from ...utils.enaml_destroy_hook import add_destroy_hook
 from ...utils.widgets.qt_list_str_widget import QtListStrWidget
 from ...utils.transformers import ids_to_unique_names

--- a/ecpy/measure/workspace/workspace.py
+++ b/ecpy/measure/workspace/workspace.py
@@ -15,7 +15,6 @@ from __future__ import (division, unicode_literals, print_function,
 import logging
 import os
 import re
-from traceback import format_exc
 
 import enaml
 from atom.api import Typed, Value, Property, set_default
@@ -24,9 +23,10 @@ from enaml.workbench.ui.api import Workspace
 from enaml.widgets.api import FileDialogEx
 from enaml.layout.api import InsertItem, InsertTab
 
+from ...utils.traceback import format_exc
+from ...tasks.api import RootTask
 from ..measure import Measure
 from ..plugin import MeasurePlugin
-from ...tasks.api import RootTask
 from .measure_tracking import MeasureTracker
 
 with enaml.imports():

--- a/ecpy/tasks/declarations.py
+++ b/ecpy/tasks/declarations.py
@@ -12,7 +12,6 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
-from traceback import format_exc
 from inspect import cleandoc
 
 from future.utils import python_2_unicode_compatible
@@ -21,6 +20,7 @@ from enaml.core.api import d_, d_func
 
 from .infos import TaskInfos, InterfaceInfos, ConfigInfos
 from ..utils.declarator import Declarator, GroupDeclarator, import_and_get
+from ..utils.traceback import format_exc
 
 
 def check_children(declarator):

--- a/ecpy/tasks/tasks/base_tasks.py
+++ b/ecpy/tasks/tasks/base_tasks.py
@@ -23,7 +23,6 @@ from collections import Iterable
 from inspect import cleandoc
 from textwrap import fill
 from copy import deepcopy
-from traceback import format_exc
 from types import MethodType
 from cProfile import Profile
 from operator import attrgetter
@@ -33,6 +32,7 @@ from atom.api import (Atom, Int, Bool, Value, Unicode, List,
                       Tuple, Coerced, Constant, set_default)
 from configobj import Section, ConfigObj
 
+from ...utils.traceback import format_exc
 from ...utils.atom_util import (tagged_members, member_to_pref,
                                 update_members_from_preferences)
 from ...utils.container_change import ContainerChange

--- a/ecpy/tasks/tasks/decorators.py
+++ b/ecpy/tasks/tasks/decorators.py
@@ -19,9 +19,10 @@ import logging
 from functools import update_wrapper
 from time import sleep
 from threading import Thread, Event, current_thread
-from traceback import format_exc
 
 from atom.api import Atom, Value, Callable, Unicode
+
+from ...utils.traceback import format_exc
 
 
 def handle_stop_pause(root):

--- a/ecpy/tasks/tasks/task_interface.py
+++ b/ecpy/tasks/tasks/task_interface.py
@@ -12,10 +12,10 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
-from traceback import format_exc
 from atom.api import (Atom, ForwardTyped, Typed, Unicode, Dict, Property,
                       Constant)
 
+from ...utils.traceback import format_exc
 from ...utils.atom_util import HasPrefAtom, tagged_members
 from .base_tasks import BaseTask
 from . import validators

--- a/ecpy/tasks/tasks/util/definition_task.py
+++ b/ecpy/tasks/tasks/util/definition_task.py
@@ -13,10 +13,10 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 from collections import OrderedDict
-from traceback import format_exc
 
 from atom.api import Typed
 
+from ....utils.traceback import format_exc
 from ....utils.atom_util import (ordered_dict_from_pref, ordered_dict_to_pref)
 from ..string_evaluation import safe_eval
 

--- a/ecpy/tasks/tasks/util/formula_task.py
+++ b/ecpy/tasks/tasks/util/formula_task.py
@@ -13,10 +13,10 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 from collections import OrderedDict
-from traceback import format_exc
 
 from atom.api import (Typed, set_default)
 
+from ....utils.traceback import format_exc
 from ....utils.atom_util import (ordered_dict_from_pref, ordered_dict_to_pref)
 
 from ..base_tasks import SimpleTask

--- a/ecpy/tasks/tasks/validators.py
+++ b/ecpy/tasks/tasks/validators.py
@@ -12,9 +12,9 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
-from traceback import format_exc
-
 from atom.api import Atom, Value, Bool
+
+from ...utils.traceback import format_exc
 
 
 class Feval(Atom):

--- a/ecpy/tasks/utils/saving.py
+++ b/ecpy/tasks/utils/saving.py
@@ -12,11 +12,11 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
-from traceback import format_exc
-
 from enaml.stdlib.message_box import critical
 
 from .templates import save_template
+from ...utils.traceback import format_exc
+
 
 import enaml
 with enaml.imports():

--- a/ecpy/utils/declarator.py
+++ b/ecpy/utils/declarator.py
@@ -14,11 +14,12 @@ from __future__ import (division, unicode_literals, print_function,
 
 import re
 from importlib import import_module
-from traceback import format_exc
 
 from future.utils import python_2_unicode_compatible
 from atom.api import Unicode, Bool
 from enaml.core.api import Declarative, d_
+
+from .traceback import format_exc
 
 
 @python_2_unicode_compatible

--- a/ecpy/utils/traceback.py
+++ b/ecpy/utils/traceback.py
@@ -20,18 +20,20 @@ register_surrogateescape()
 if sys.version_info >= (3,):
     from traceback import format_exc, format_tb
 else:
+    # Returns a single string
     def format_exc():
-        """Decode and format the current traceback in a safe way.
+        """Format and decode the current traceback in a safe way.
 
         """
         from traceback import format_exc
         return format_exc().decode('utf-8', 'surrogateescape')
 
+    # Returns a list of strings
     def format_tb(tb):
         """Format and decode a traceback in a safe way.
 
         """
         from traceback import format_tb
-        return format_tb(tb).decode('utf-8', 'surrogateescape')
+        return [e.decode('utf-8', 'surrogateescape') for e in format_tb(tb)]
 
 __all__ = ['format_exc', 'format_tb']

--- a/ecpy/utils/traceback.py
+++ b/ecpy/utils/traceback.py
@@ -17,7 +17,7 @@ import sys
 from future.utils.surrogateescape import register_surrogateescape
 register_surrogateescape()
 
-if sys.version_info >= 3:
+if sys.version_info >= (3,):
     from traceback import format_exc, format_tb
 else:
     def format_exc():

--- a/ecpy/utils/traceback.py
+++ b/ecpy/utils/traceback.py
@@ -21,9 +21,17 @@ if sys.version_info >= 3:
     from traceback import format_exc, format_tb
 else:
     def format_exc():
+        """Decode and format the current traceback in a safe way.
+
+        """
         from traceback import format_exc
         return format_exc().decode('utf-8', 'surrogateescape')
 
     def format_tb(tb):
+        """Format and decode a traceback in a safe way.
+
+        """
         from traceback import format_tb
         return format_tb(tb).decode('utf-8', 'surrogateescape')
+
+__all__ = ['format_exc', 'format_tb']

--- a/ecpy/utils/traceback.py
+++ b/ecpy/utils/traceback.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2015 by Ecpy Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Utility functions to generate well behaved tracebacks
+
+"""
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
+
+import sys
+
+from future.utils.surrogateescape import register_surrogateescape
+register_surrogateescape()
+
+if sys.version_info >= 3:
+    from traceback import format_exc, format_tb
+else:
+    def format_exc():
+        from traceback import format_exc
+        return format_exc().decode('utf-8', 'surrogateescape')
+
+    def format_tb(tb):
+        from traceback import format_tb
+        return format_tb(tb).decode('utf-8', 'surrogateescape')


### PR DESCRIPTION
This makes sure that format_exc returns a unicode string and use surrogate escape to avoid issue in the decoding as can happen on Windows (French)

@lcontami this should fix the issue you have been seeing, so could you review it ?