### PR TITLE
measure: fix execution layout bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ env:
 
 matrix:
   include:
-    - env: PYTHON=2.7 CONDA_PY=27 QT_VERSION=4
-    - env: PYTHON=3.4 CONDA_PY=34 QT_VERSION=4
-    - env: PYTHON=3.5 CONDA_PY=35 QT_VERSION=5
-    - env: PYTHON=3.6 CONDA_PY=36 QT_VERSION=5
+    - env: PYTHON=2.7 CONDA_PY=2.7 QT_VERSION=4
+    - env: PYTHON=3.4 CONDA_PY=3.4 QT_VERSION=4
+    - env: PYTHON=3.5 CONDA_PY=3.5 QT_VERSION=5
+    - env: PYTHON=3.6 CONDA_PY=3.6 QT_VERSION=5
 
 before_install:
 

--- a/docs/source/user_guide/measure_edition.rst
+++ b/docs/source/user_guide/measure_edition.rst
@@ -62,6 +62,15 @@ be executed. Three parameters are editable :
   which parallel pool to wait on (hence the id), or not to wait on some pools
   or to wait on all pools.
 
+Task pools
+""""""""""
+
+A pool simply consist in a user-defined group of tasks.
+In a measure, each task can be associated with a pool from the dropdown menu
+of the execution editor. To define a new pool, right click on the menu and
+enter a name. You will then be able to select one or multiple of you defined
+pool(s) in the wait or no wait options.
+
 .. note::
 
     It is possible to run a task in parallel and have it wait on other pools.

--- a/ecpy/measure/editors/execution_editor/editor.enaml
+++ b/ecpy/measure/editors/execution_editor/editor.enaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright 2015 by Ecpy Authors, see AUTHORS for more details.
+# Copyright 2015-2017 by Ecpy Authors, see AUTHORS for more details.
 #
 # Distributed under the terms of the BSD license.
 #
@@ -13,11 +13,11 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 from operator import attrgetter
-from collections import Iterable
+from collections import Iterable, OrderedDict
 from time import sleep
 
 from enaml.widgets.api import (Container, GroupBox, CheckBox, ScrollArea,
-                               PopupView, Field, RadioButton,
+                               PopupView, Field, RadioButton, HGroup,
                                ObjectCombo, PushButton, Menu, Action)
 from enaml.core.api import Looper, Conditional, Include
 from enaml.layout.api import vbox, hbox, spacer
@@ -125,10 +125,14 @@ enamldef _BaseExecutionEditor(Container):
     #: Reference to the model keeping track of the pools currently used.
     attr _model
 
-    padding = 0
+    padding = 1
+
     constraints << [hbox(stop,
-                         *((parallel,) + tuple(par_cond.items) + (wait,)
-                           + tuple(wai_cond.items) + (spacer,)))]
+                         *((parallel,) +
+                           ((par_comb,) if par_comb.visible else ()) +
+                           (wait,) +
+                           ((wai_cond,) if wai_cond.visible else ()) +
+                           (spacer,)))]
 
     CheckBox: stop:
         text = 'Stoppable'
@@ -139,11 +143,6 @@ enamldef _BaseExecutionEditor(Container):
         hug_width = 'strong'
 
     CheckBox: parallel:
-        # Workaround the fact that otherwise when the checkbox is unchecked
-        # the declaration for the ObjectCombo in par_cond is destroyed but the
-        # qt object try to refresh its items given the async nature of enaml.
-        attr active : bool = checked
-
         text = 'Parallel'
         tool_tip = 'Should this task perform its job in parallel (new thread).'
         hug_width = 'strong'
@@ -151,35 +150,26 @@ enamldef _BaseExecutionEditor(Container):
         checked ::
             _set_parallel(task, 'activated', change['value'])
 
-            parallel.active = change['value']
+    ObjectCombo: par_comb:
+        #: Way for the popup to send its answer (popup is non-blocking)
+        event answer
 
-    # Select parallel pool of execution.
-    Conditional: par_cond:
-        condition << parallel.active
+        items << _model.pools
+        visible << parallel.checked
+        selected << task.parallel.get('pool')
+        selected ::
+            _set_parallel(task, 'pool', change['value'])
+        answer ::
+            _set_parallel(task, 'pool', change['value'])
+        tool_tip = 'Right-click to declare a new pool.'
 
-        ObjectCombo: par_comb:
-            #: Way for the popup to send its answer (popup is non-blocking)
-            attr answer
-
-            items << _model.pools
-            selected << task.parallel.get('pool')
-            selected ::
-                _set_parallel(task, 'pool', change['value'])
-            answer ::
-                _set_parallel(task, 'pool', change['value'])
-            tool_tip = 'Right-click to declare a new pool.'
-
-            Menu:
-                context_menu = True
-                Action:
-                    text = 'Add new pool'
-                    initialized::
-                        # Need to init the value so that the popup answer is
-                        # signaled.
-                        par_comb.answer = '__gg__'
-                    triggered ::
-                        popup = _PopupField(par_comb)
-                        popup.show()
+        Menu:
+            context_menu = True
+            Action:
+                text = 'Add new pool'
+                triggered ::
+                    popup = _PopupField(par_comb)
+                    popup.show()
 
     CheckBox: wait:
         text = 'Wait'
@@ -190,8 +180,11 @@ enamldef _BaseExecutionEditor(Container):
         checked ::
             _set_wait(task, 'activated', change['value'])
 
-    Conditional: wai_cond:
-        condition << wait.checked
+    HGroup: wai_cond:
+
+        visible << wait.checked
+        padding = 1
+        trailing_spacer = spacer
 
         #: Currently selected pool to wait on.
         attr selected << set(task.wait.get('wait', []) +
@@ -224,14 +217,11 @@ enamldef _BaseExecutionEditor(Container):
         PushButton:
 
             #: Way for the popup to send its answer (popup is non-blocking)
-            attr answer
+            event answer
 
             text = 'Edit'
             hug_width = 'strong'
 
-            initialized ::
-                # Need to init the value so that the popup answer is signaled.
-                self.answer = ['']
             clicked ::
                 sel = wai_cond.selected.copy()
                 popup = _PopupList(self, selected=sel,
@@ -266,7 +256,7 @@ enamldef SimpleTaskExecutionEditor(GroupBox):
 
     title = task.name
 
-    padding = 0
+    padding = 1
 
     _BaseExecutionEditor: ed:
         pass
@@ -289,54 +279,39 @@ enamldef ComplexTaskExecutionEditor(GroupBox): main:
     #: Reference to the model driving the whole execution property edition.
     attr _model
 
+    #: List of task that should be displayed by the editor. Keep cached
+    #: to determine the modifications
+    attr _tasks = OrderedDict()
+
     func refresh():
         """Function making sure that the editor is displayed correctly.
 
         """
-        self.show()
-        for ed in tag.objects:
-            ed.set_parent(main)
+        # First update the children before showing the widget
+        for ed in _tasks.values():
+            ed.set_parent(c_tag)
             ed.refresh()
+        c_tag.request_relayout()
+        self.show()
 
     func populate_tagged_children(change=None):
         """Refresh the editors for the included tagged children.
 
         """
-        if isinstance(change, dict) and 'oldvalue' in change:
-            if isinstance(change['oldvalue'], Iterable):
-                removed = set(change['oldvalue']) - set(change['value'])
-                for t in removed:
-                    root.discard_view(t)
-            else:
-                root.discard_view(change['oldvalue'])
-        elif change is not None:
-            if change.collapsed:
-                for c in change.collapsed:
-                    for _, t in c.removed:
-                        root.discard_view(t)
-            else:
-                for _, t in change.removed:
-                    root.discard_view(t)
+        tasks = task.gather_children()
+        added = set(tasks) - set(self._tasks)
+        removed = set(self._tasks) - set(tasks)
+        self._tasks = OrderedDict([(t, root.view_for(t)) for t in tasks])
 
-        views = []
-        for child in task.gather_children():
-            v = root.view_for(child)
-            v.visible = main.show_children
-            views.append(v)
+        for t in removed:
+            root.discard_view(t)
 
-        tag.objects = views
+        for t in added:
+            _tasks[t].set_parent(c_tag)
+
+        c_tag.request_relayout()
 
     title = task.name if task else ''
-
-    layout_constraints => ():
-        """Setup the constraints for the children.
-
-        """
-        children = self.visible_widgets()
-        constraints = [vbox(*(tuple(children) + (spacer,)))]
-        for child in children:
-            constraints.append(child.left == contents_left)
-        return constraints
 
     initialized ::
         for m in tagged_members(task, 'child'):
@@ -353,19 +328,24 @@ enamldef ComplexTaskExecutionEditor(GroupBox): main:
             _model = main._model
 
     PushButton:
-        text << '-' if c_tag.visible else '+'
+        text << '-' if show_children else '+'
         constraints = [height == 10]
         clicked ::
             main.show_children = not show_children
 
     Container: c_tag:
-        padding = 0
+        padding = 1
         visible << show_children
-        visible ::
-            for o in tag.objects:
-                o.visible = visible
-        Include: tag:
-            pass
+
+        layout_constraints => ():
+            """Setup the constraints for the children.
+
+            """
+            views = _tasks.values()
+            constraints = [vbox(*(tuple(views) + (spacer,)))]
+            for child in children:
+                constraints.append(child.left == contents_left)
+            return constraints
 
 
 enamldef ExecutionEditor(BaseEditor): editor:
@@ -421,7 +401,7 @@ enamldef ExecutionEditor(BaseEditor): editor:
         if task:
             view = view_for(task)
             # HINT this is needed because otherwise we try to relayout tasks
-            # that should not be relaid out because there are not diplayed
+            # that should not be relaid out because there are not displayed
             # anymore and should be the layout parent of the displayed task.
             # (RootTask for a complex one).
             # This is Qt specific

--- a/ecpy/measure/editors/execution_editor/editor.enaml
+++ b/ecpy/measure/editors/execution_editor/editor.enaml
@@ -386,10 +386,18 @@ enamldef ExecutionEditor(BaseEditor): editor:
         """
         try:
             view = _cache.pop(task)
+            # Make sure all children are parented and will hence be properly
+            # destroyed
+            view.refresh()
             view.set_parent(None)
             view.destroy()
         except KeyError:
             pass
+        else:
+            # Remove all views that have been destroyed because their
+            # parent was just destroyed
+            self._cache = {k: v for k, v in _cache.items()
+                           if not v.is_destroyed}
 
     func set_view_for(task):
         """Set the currently displayed widget to match the selected view.

--- a/ecpy/tasks/tasks/base_views.enaml
+++ b/ecpy/tasks/tasks/base_views.enaml
@@ -155,11 +155,15 @@ enamldef RootTaskView(BaseTaskView): main:
         """
         try:
             view = _cache.pop(task)
+            # Make sure all children are parented and will hence be properly
+            # destroyed.
+            view.refresh()
+            view.set_parent(None)
             view.destroy()
         except KeyError:
             pass
         else:
-            # Remove all views that may have been destroyed because their
+            # Remove all views that have been destroyed because their
             # parent was just destroyed
             self._cache = {k: v for k, v in _cache.items()
                            if not v.is_destroyed}

--- a/tests/measure/editors/test_execution_editor.py
+++ b/tests/measure/editors/test_execution_editor.py
@@ -12,6 +12,8 @@
 from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
+from time import sleep
+                        
 import pytest
 import enaml
 
@@ -214,7 +216,9 @@ def test_execution_editor_widget(windows, task, process_and_sleep):
 
     # Create a new pool using the context menu on parallell
     ced.widgets()[2].children[0].children[0].triggered = True
-    process_and_sleep()
+    # This can fails on Travis if we do not sleep
+    process_app_events()
+    sleep(1)
     process_app_events()  # So that the popup shows correctly
     popup_content = get_popup_content(ced.widgets()[2])
     popup_content[0].text = 'test3'
@@ -225,7 +229,9 @@ def test_execution_editor_widget(windows, task, process_and_sleep):
 
     # Create a new pool using the context menu on parallell, but cancel it
     ced.widgets()[2].children[0].children[0].triggered = True
-    process_and_sleep()
+    # This can fails on Travis if we do not sleep
+    process_app_events()
+    sleep(1)
     process_app_events()  # So that the popup shows correctly
     popup_content = get_popup_content(ced.widgets()[2])
     popup_content[0].text = 'test4'


### PR DESCRIPTION
This should fix the numerous bugs of display in the execution editor.
Basically the issues were:
- over complicated logic 
- some very stupid mistake in parenting manually the widget in refresh to the top widget when they should be parented to the container holding them
- some stupidly placed contraints

I still need to do some tests but fell free to ask for clarifications, it deserves probably more comments.