### PR TITLE
Miscellaneous fixes in task editors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,15 @@
 Ecpy Changelog
 ==============
 
-0.1.0 - 29/06/2017
-------------------
+0.1.0 - to be released
+----------------------
 
+- measure: fix all found bugs of execution editor (#110)
+- measure: fix all found bugs of database access editor (#110)
+- measure: remove measure from the list of edited ones when loading (#110)
+- measure: fix bug when switching workspaces after loading a measure (#110)
+- measure: fix reference leak of old measures (#110)
+- widgets: more homogoneous behavior of drag and drop in the tree (#110)
 - tasks: fix collections of instr dependencies of interfaces (#99)
 - tasks: allow for no views for an interface (#97)
 - utils: use surrogate escape on Python 2 when decoding formatted traceback (#100)

--- a/docs/source/user_guide/measure_edition.rst
+++ b/docs/source/user_guide/measure_edition.rst
@@ -62,6 +62,15 @@ be executed. Three parameters are editable :
   which parallel pool to wait on (hence the id), or not to wait on some pools
   or to wait on all pools.
 
+Task pools
+""""""""""
+
+A pool simply consist in a user-defined group of tasks.
+In a measure, each task can be associated with a pool from the dropdown menu
+of the execution editor. To define a new pool, right click on the menu and
+enter a name. You will then be able to select one or multiple of you defined
+pool(s) in the wait or no wait options.
+
 .. note::
 
     It is possible to run a task in parallel and have it wait on other pools.

--- a/ecpy/__main__.py
+++ b/ecpy/__main__.py
@@ -273,7 +273,8 @@ def main(cmd_line_args=None):
     core = workbench.get_plugin('enaml.workbench.core')
 
     # Install global except hook.
-    core.invoke_command('ecpy.app.errors.install_excepthook', {})
+    if not args.nocapture:
+        core.invoke_command('ecpy.app.errors.install_excepthook', {})
 
     # Select workspace
     core.invoke_command('enaml.workbench.ui.select_workspace',

--- a/ecpy/app/log/plugin.py
+++ b/ecpy/app/log/plugin.py
@@ -85,7 +85,7 @@ class LogPlugin(Plugin):
         logger.addHandler(handler)
 
         self._handlers[id] = (handler, name)
-        self.handler_ids = self._handlers.keys()
+        self.handler_ids = list(self._handlers.keys())
 
         if refs:
             return refs
@@ -104,13 +104,13 @@ class LogPlugin(Plugin):
             handler, logger_name = handlers.pop(id)
             logger = logging.getLogger(logger_name)
             logger.removeHandler(handler)
-            for filter_id in self._filters.keys():
+            for filter_id in self.filter_ids:
                 infos = self._filters[filter_id]
                 if infos[1] == id:
                     del self._filters[filter_id]
 
-            self.filter_ids = self._filters.keys()
-            self.handler_ids = self._handlers.keys()
+            self.filter_ids = list(self._filters.keys())
+            self.handler_ids = list(self._handlers.keys())
 
     def add_filter(self, id, filter, handler_id):
         """Add a filter to the specified handler.
@@ -139,7 +139,7 @@ class LogPlugin(Plugin):
             handler.addFilter(filter)
             self._filters[id] = (filter, handler_id)
 
-            self.filter_ids = self._filters.keys()
+            self.filter_ids = list(self._filters.keys())
 
         else:
             logger = logging.getLogger(__name__)
@@ -159,7 +159,7 @@ class LogPlugin(Plugin):
             filter, handler_id = filters.pop(id)
             handler, _ = self._handlers[handler_id]
             handler.removeFilter(filter)
-            self.filter_ids = self._filters.keys()
+            self.filter_ids = list(self._filters.keys())
 
     def set_formatter(self, handler_id, formatter):
         """Set the formatter of the specified handler.

--- a/ecpy/measure/editors/database_access_editor/editor.enaml
+++ b/ecpy/measure/editors/database_access_editor/editor.enaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright 2015 by Ecpy Authors, see AUTHORS for more details.
+# Copyright 2015-2017 by Ecpy Authors, see AUTHORS for more details.
 #
 # Distributed under the terms of the BSD license.
 #
@@ -17,17 +17,35 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 from time import sleep
+from collections import OrderedDict
 
 from enaml.widgets.api import (Container, GroupBox, ScrollArea, Menu, Action,
-                               Label, FlowArea, FlowItem)
+                               Label, FlowArea, FlowItem, PushButton)
 from enaml.core.api import Looper, Conditional
+from enaml.layout.api import vbox, spacer
+from enaml.styling import StyleSheet, Style, Setter
 
 from ....tasks.tasks.task_editor import FoldableTaskEditor
 from ..base_editor import BaseEditor
 from .editor_model import EditorModel
 
 
-enamldef NodeEditor(GroupBox):
+enamldef BlueLabel(StyleSheet):
+    """Style sheet setting the background to lighblue
+
+    For unclear reasons this gives more consistent results than setting the
+    background member.
+
+    """
+    Style:
+        style_class = 'blue'
+        Setter:
+            field = 'background'
+            value = 'lightblue'
+
+
+
+enamldef NodeEditor(GroupBox): main:
     """Access editor for a NodeModel.
 
     """
@@ -35,7 +53,13 @@ enamldef NodeEditor(GroupBox):
     attr node
 
     #: Reference to the root view holding the cache.
-    alias root : ed.root
+    attr root
+
+    #: Should the children be shown
+    attr show_children : bool = True
+
+    #: Reference to the nodes view in the proper order
+    attr _nodes = OrderedDict()
 
     title << node.task.name if node else ''
 
@@ -48,10 +72,39 @@ enamldef NodeEditor(GroupBox):
         """Function making sure that the editor is displayed correctly.
 
         """
-        ed.refresh()
+        # First update the children before showing the widget
+        for ed in _nodes.values():
+            ed.set_parent(c_nodes)
+            ed.refresh()
+        c_nodes.request_relayout()
         self.show()
 
+    func populate_nodes(change=None):
+        """Refresh the editors for the included nodes.
+
+        """
+        nodes = node.children
+        added = set(nodes) - set(self._nodes)
+        removed = set(self._nodes) - set(nodes)
+        self._nodes = OrderedDict([(n, root.view_for(n)) for n in nodes])
+
+        for n in removed:
+            root.discard_view(n)
+
+        for n in added:
+            _nodes[n].set_parent(c_nodes)
+
+        c_nodes.request_relayout()
+
+    initialized ::
+        node.observe('children', self.populate_nodes)
+        populate_nodes()
+
+    BlueLabel:
+        pass
+
     FlowArea:
+        resist_height = 'ignore'
         hug_height = 'medium'
         hug_width = 'ignore'
 
@@ -62,9 +115,9 @@ enamldef NodeEditor(GroupBox):
                     padding = 0
                     Label:
                         text << loop_item
-                        background << ('lightblue'
-                                       if loop_item in node.has_exceptions
-                                       else None)
+                        style_class << ('blue'
+                                        if loop_item in node.has_exceptions
+                                        else '')
                         Conditional:
                             condition << (node.task.depth != 0 and
                                           loop_item not in node.has_exceptions)
@@ -90,7 +143,7 @@ enamldef NodeEditor(GroupBox):
                                 Action:
                                     text = 'Move up'
                                     triggered ::
-                                        e = node.editor
+                                        e = root.database_model
                                         t = node.task
                                         p = t.path + '/' + t.name
                                         e.increase_exc_level(p, loop_item)
@@ -100,16 +153,38 @@ enamldef NodeEditor(GroupBox):
                                             'node, if necessary removing it '
                                             'completetly')
                                 triggered ::
-                                    e = node.editor
+                                    e = root.database_model
                                     t = node.task
                                     p = (t.path + '/' + t.name if t.depth
                                          else t.path)
                                     e.decrease_exc_level(p, loop_item)
 
-    FoldableTaskEditor: ed:
-        # This abuses the task editor but it is really nice.
-        task = node
-        operations = {}
+    PushButton:
+        text << '-' if show_children else '+'
+        constraints = [height == 10]
+        clicked ::
+            main.show_children = not show_children
+            c_nodes.request_relayout()
+
+    Container: c_nodes:
+        padding = 1
+        visible << show_children
+
+        layout_constraints => ():
+            """Setup the constraints for the children.
+
+            This is necessary to avoid that the widget takes more space than
+            necessary.
+
+            """
+            if show_children:
+                views = _nodes.values()
+                constraints = [vbox(*(tuple(views) + (spacer,)))]
+                for child in children:
+                    constraints.append(child.left == contents_left)
+                return constraints
+            else:
+                return []
 
 
 enamldef DatabaseAccessEditor(BaseEditor): main:
@@ -137,18 +212,26 @@ enamldef DatabaseAccessEditor(BaseEditor): main:
 
         """
         try:
-            view = _cache.pop(task)
+            view = _cache.pop(node)
+            # Make sure all children are parented and will hence be properly
+            # destroyed
+            view.refresh()
+            view.set_parent(None)
             view.destroy()
         except KeyError:
             pass
+        else:
+            # Remove all views that have been destroyed because their
+            # parent was just destroyed
+            self._cache = {k: v for k, v in _cache.items()
+                           if not v.is_destroyed}
 
     func set_view_for(task):
         """Set the currently displayed widget to match the selected view.
 
         """
-        if not database_model:
+        if not main.database_model:
             main.database_model = EditorModel(root=task.root)
-            main.database_model.observe('node_deleted', discard_view)
 
         if task:
             if task.name == 'Root':
@@ -157,7 +240,7 @@ enamldef DatabaseAccessEditor(BaseEditor): main:
                 node = database_model.nodes[task.path + '/' + task.name]
             view = view_for(node)
             # HINT this is needed because otherwise we try to relayout tasks
-            # that should not be relaid out because there are not diplayed
+            # that should not be relaid out because there are not displayed
             # anymore and should be the layout parent of the displayed task.
             # (RootTask for a complex one).
             # This is Qt specific
@@ -187,9 +270,16 @@ enamldef DatabaseAccessEditor(BaseEditor): main:
         # to speed up a bit the process.
         nodes = sorted(_cache, key=lambda n: n.task.depth)
         for n in nodes:
-            view = _cache[n]
+            view = _cache.pop(n)
             if not view.is_destroyed:
                 view.destroy()
+            # Manually breaking the reference cycles reduce the gc work
+            n.task = None
+            view.root = None
+        # Manually breaking the reference cycles reduce the gc work
+        if database_model:
+            database_model.root = None
+            self.database_model = None
 
     Container:
         ScrollArea: scroll:

--- a/ecpy/measure/editors/execution_editor/editor.enaml
+++ b/ecpy/measure/editors/execution_editor/editor.enaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright 2015 by Ecpy Authors, see AUTHORS for more details.
+# Copyright 2015-2017 by Ecpy Authors, see AUTHORS for more details.
 #
 # Distributed under the terms of the BSD license.
 #
@@ -13,11 +13,12 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 from operator import attrgetter
-from collections import Iterable
+from collections import Iterable, OrderedDict
 from time import sleep
 
+from atom.api import Value, Typed
 from enaml.widgets.api import (Container, GroupBox, CheckBox, ScrollArea,
-                               PopupView, Field, RadioButton,
+                               PopupView, Field, RadioButton, HGroup,
                                ObjectCombo, PushButton, Menu, Action)
 from enaml.core.api import Looper, Conditional, Include
 from enaml.layout.api import vbox, hbox, spacer
@@ -125,10 +126,14 @@ enamldef _BaseExecutionEditor(Container):
     #: Reference to the model keeping track of the pools currently used.
     attr _model
 
-    padding = 0
+    padding = 1
+
     constraints << [hbox(stop,
-                         *((parallel,) + tuple(par_cond.items) + (wait,)
-                           + tuple(wai_cond.items) + (spacer,)))]
+                         *((parallel,) +
+                           ((par_comb,) if par_comb.visible else ()) +
+                           (wait,) +
+                           ((wai_cond,) if wai_cond.visible else ()) +
+                           (spacer,)))]
 
     CheckBox: stop:
         text = 'Stoppable'
@@ -139,11 +144,6 @@ enamldef _BaseExecutionEditor(Container):
         hug_width = 'strong'
 
     CheckBox: parallel:
-        # Workaround the fact that otherwise when the checkbox is unchecked
-        # the declaration for the ObjectCombo in par_cond is destroyed but the
-        # qt object try to refresh its items given the async nature of enaml.
-        attr active : bool = checked
-
         text = 'Parallel'
         tool_tip = 'Should this task perform its job in parallel (new thread).'
         hug_width = 'strong'
@@ -151,35 +151,26 @@ enamldef _BaseExecutionEditor(Container):
         checked ::
             _set_parallel(task, 'activated', change['value'])
 
-            parallel.active = change['value']
+    ObjectCombo: par_comb:
+        #: Way for the popup to send its answer (popup is non-blocking)
+        event answer
 
-    # Select parallel pool of execution.
-    Conditional: par_cond:
-        condition << parallel.active
+        items << _model.pools
+        visible << parallel.checked
+        selected << task.parallel.get('pool')
+        selected ::
+            _set_parallel(task, 'pool', change['value'])
+        answer ::
+            _set_parallel(task, 'pool', change['value'])
+        tool_tip = 'Right-click to declare a new pool.'
 
-        ObjectCombo: par_comb:
-            #: Way for the popup to send its answer (popup is non-blocking)
-            attr answer
-
-            items << _model.pools
-            selected << task.parallel.get('pool')
-            selected ::
-                _set_parallel(task, 'pool', change['value'])
-            answer ::
-                _set_parallel(task, 'pool', change['value'])
-            tool_tip = 'Right-click to declare a new pool.'
-
-            Menu:
-                context_menu = True
-                Action:
-                    text = 'Add new pool'
-                    initialized::
-                        # Need to init the value so that the popup answer is
-                        # signaled.
-                        par_comb.answer = '__gg__'
-                    triggered ::
-                        popup = _PopupField(par_comb)
-                        popup.show()
+        Menu:
+            context_menu = True
+            Action:
+                text = 'Add new pool'
+                triggered ::
+                    popup = _PopupField(par_comb)
+                    popup.show()
 
     CheckBox: wait:
         text = 'Wait'
@@ -190,8 +181,11 @@ enamldef _BaseExecutionEditor(Container):
         checked ::
             _set_wait(task, 'activated', change['value'])
 
-    Conditional: wai_cond:
-        condition << wait.checked
+    HGroup: wai_cond:
+
+        visible << wait.checked
+        padding = 1
+        trailing_spacer = spacer
 
         #: Currently selected pool to wait on.
         attr selected << set(task.wait.get('wait', []) +
@@ -224,14 +218,11 @@ enamldef _BaseExecutionEditor(Container):
         PushButton:
 
             #: Way for the popup to send its answer (popup is non-blocking)
-            attr answer
+            event answer
 
             text = 'Edit'
             hug_width = 'strong'
 
-            initialized ::
-                # Need to init the value so that the popup answer is signaled.
-                self.answer = ['']
             clicked ::
                 sel = wai_cond.selected.copy()
                 popup = _PopupList(self, selected=sel,
@@ -244,6 +235,7 @@ enamldef _BaseExecutionEditor(Container):
                     task.wait = dict(activated=True, no_wait=list(new_sel))
                 else:
                     task.wait = dict(activated=True, wait=list(new_sel))
+
 
 enamldef SimpleTaskExecutionEditor(GroupBox):
     """Editor specialized in handling SimpleTask subclasses.
@@ -266,20 +258,66 @@ enamldef SimpleTaskExecutionEditor(GroupBox):
 
     title = task.name
 
-    padding = 0
+    padding = 1
 
     _BaseExecutionEditor: ed:
         pass
 
 
-enamldef ComplexTaskExecutionEditor(GroupBox): main:
+class _BaseComplexTaskExecutionEditor(GroupBox):
+    """Base view handling the observation.
+
+    """
+    #: Reference to the task this editor is linked to.
+    task = Value()
+
+    #: List of task that should be displayed by the editor. Keep cached
+    #: to determine the modifications
+    _tasks = Typed(OrderedDict, ())
+
+    def __init__(self, parent, **kwargs):
+        super(_BaseComplexTaskExecutionEditor, self).__init__(parent, **kwargs)
+        for m in tagged_members(self.task, 'child'):
+            self.task.observe(m, self.populate_tagged_children)
+        for m in tagged_members(self.task, 'child_notifier'):
+            self.task.observe(m, self.populate_tagged_children)
+        self.populate_tagged_children()
+
+    def destroy(self):
+        """Clear the _tasks cache to avoid any issue.
+
+        """
+        for m in tagged_members(self.task, 'child'):
+            self.task.unobserve(m, self.populate_tagged_children)
+        for m in tagged_members(self.task, 'child_notifier'):
+            self.task.unobserve(m, self.populate_tagged_children)
+        self._tasks.clear()
+        super(_BaseComplexTaskExecutionEditor, self).destroy()
+
+    def populate_tagged_children(self, change=None):
+        """Refresh the editors for the included tagged children.
+
+        """
+        tasks = self.task.gather_children()
+        added = set(tasks) - set(self._tasks)
+        removed = set(self._tasks) - set(tasks)
+        self._tasks = OrderedDict([(t, self.root.view_for(t)) for t in tasks])
+
+        for t in removed:
+            self.root.discard_view(t)
+
+        c_tag = self.children[-1]
+
+        for t in added:
+            self._tasks[t].set_parent(c_tag)
+
+        c_tag.request_relayout()
+
+
+enamldef ComplexTaskExecutionEditor(_BaseComplexTaskExecutionEditor): main:
     """Editor specialized in handling ComplexTask subclasses.
 
     """
-
-    #: Reference to the task this editor is linked to.
-    attr task
-
     #: Reference to the root editor managing the cache.
     attr root
 
@@ -293,79 +331,48 @@ enamldef ComplexTaskExecutionEditor(GroupBox): main:
         """Function making sure that the editor is displayed correctly.
 
         """
-        self.show()
-        for ed in tag.objects:
-            ed.set_parent(main)
+        # First update the children before showing the widget
+        for ed in _tasks.values():
+            ed.set_parent(c_tag)
             ed.refresh()
+        c_tag.request_relayout()
+        self.show()
 
-    func populate_tagged_children(change=None):
-        """Refresh the editors for the included tagged children.
-
-        """
-        if isinstance(change, dict) and 'oldvalue' in change:
-            if isinstance(change['oldvalue'], Iterable):
-                removed = set(change['oldvalue']) - set(change['value'])
-                for t in removed:
-                    root.discard_view(t)
-            else:
-                root.discard_view(change['oldvalue'])
-        elif change is not None:
-            if change.collapsed:
-                for c in change.collapsed:
-                    for _, t in c.removed:
-                        root.discard_view(t)
-            else:
-                for _, t in change.removed:
-                    root.discard_view(t)
-
-        views = []
-        for child in task.gather_children():
-            v = root.view_for(child)
-            v.visible = main.show_children
-            views.append(v)
-
-        tag.objects = views
-
-    title = task.name if task else ''
-
-    layout_constraints => ():
-        """Setup the constraints for the children.
-
-        """
-        children = self.visible_widgets()
-        constraints = [vbox(*(tuple(children) + (spacer,)))]
-        for child in children:
-            constraints.append(child.left == contents_left)
-        return constraints
-
-    initialized ::
-        for m in tagged_members(task, 'child'):
-            task.observe(m, self.populate_tagged_children)
-        for m in tagged_members(task, 'child_notifier'):
-            task.observe(m, self.populate_tagged_children)
-        populate_tagged_children()
+    title << task.name if task else ''
 
     # The root task does not have that kind of settings
     Conditional:
-        condition << task.depth != 0
+        condition << task.depth != 0 if task else False
         _BaseExecutionEditor:
             task = main.task
             _model = main._model
 
     PushButton:
-        text << '-' if c_tag.visible else '+'
+        text << '-' if show_children else '+'
         constraints = [height == 10]
         clicked ::
             main.show_children = not show_children
+            c_tag.request_relayout()
 
     Container: c_tag:
-        padding = 0
+        padding = 1
         visible << show_children
-        visible ::
-            for o in tag.objects:
-                o.visible = visible
-        Include: tag:
-            pass
+
+        layout_constraints => ():
+            """Setup the constraints for the children.
+
+            This is necessary to avoid that the widget takes more space than
+            necessary.
+
+            """
+            if show_children:
+                views = _tasks.values()
+                constraints = [vbox(*(tuple(views) + (spacer,)))]
+                for child in children:
+                    constraints.append(child.left == contents_left)
+                return constraints
+            else:
+                return []
 
 
 enamldef ExecutionEditor(BaseEditor): editor:
@@ -406,10 +413,18 @@ enamldef ExecutionEditor(BaseEditor): editor:
         """
         try:
             view = _cache.pop(task)
+            # Make sure all children are parented and will hence be properly
+            # destroyed
+            view.refresh()
             view.set_parent(None)
             view.destroy()
         except KeyError:
             pass
+        else:
+            # Remove all views that have been destroyed because their
+            # parent was just destroyed
+            self._cache = {k: v for k, v in _cache.items()
+                           if not v.is_destroyed}
 
     func set_view_for(task):
         """Set the currently displayed widget to match the selected view.
@@ -421,7 +436,7 @@ enamldef ExecutionEditor(BaseEditor): editor:
         if task:
             view = view_for(task)
             # HINT this is needed because otherwise we try to relayout tasks
-            # that should not be relaid out because there are not diplayed
+            # that should not be relaid out because there are not displayed
             # anymore and should be the layout parent of the displayed task.
             # (RootTask for a complex one).
             # This is Qt specific
@@ -451,9 +466,16 @@ enamldef ExecutionEditor(BaseEditor): editor:
         # to speed up a bit the process.
         tasks = sorted(_cache, key=attrgetter('depth'))
         for t in tasks:
-            view = _cache[t]
+            view = _cache.pop(t)
             if not view.is_destroyed:
                 view.destroy()
+            # Manually breaking the reference cycles reduce the gc work
+            view.root = None
+            # We do not do the same for task as it is not needed and weird to
+            # a very weird KeyError.
+        # Manually breaking the reference cycles reduce the gc work
+        if pool_model:
+            pool_model.root = None
 
     Container: cont:
         padding = 2

--- a/ecpy/measure/workspace/workspace.py
+++ b/ecpy/measure/workspace/workspace.py
@@ -251,9 +251,33 @@ class MeasureSpace(Workspace):
         if dock_item is None:
             self._insert_new_edition_panels((measure,))
         else:
+            # If we were passed a dock item it means we are replacing an
+            # existing measure with a different one, so the previous one is
+            # not edited anymore.
+            self.plugin.edited_measures.remove((dock_item.measure,))
             dock_item.measure = measure
 
         self._selection_tracker.set_selected_measure(measure)
+
+        # HINT: code used to track ref leak to root task
+        # requires to activtae root task instance tracking in tasks.base_tasks
+#        def print_infos(root):
+#            import gc
+#            gc.collect()
+#            import inspect
+#            from ecpy.tasks.tasks.base_tasks import ROOTS
+#            for r in ROOTS:
+#                if r is not root:
+#                    refs = [ref for ref in gc.get_referrers(r)
+#                            if not inspect.isframe(ref)]
+#                    print(('Root', refs))
+#                    for ref in refs:
+#                        print((ref,
+#                               [re for re in gc.get_referrers(ref)
+#                                if re is not refs and
+#                                   not inspect.isframe(re)]))
+#
+#        deferred_call(print_infos, measure.root_task)
 
     # TODO : making this asynchronous or notifying the user would be super nice
     def enqueue_measure(self, measure):

--- a/ecpy/tasks/tasks/base_tasks.py
+++ b/ecpy/tasks/tasks/base_tasks.py
@@ -655,7 +655,7 @@ class ComplexTask(BaseTask):
     #: List of all the children of the task. The list should not be manipulated
     #: directly by user code.
     #: The tag 'child' is used to mark that a member can contain child tasks
-    #: and is used gather children for operation which must occur on all of
+    #: and is used to gather children for operation which must occur on all of
     #: them.
     children = List().tag(child=100)
 
@@ -1021,6 +1021,10 @@ class ComplexTask(BaseTask):
             child.parent = self
             child.root = self.root
 
+# HINT: RootTask instance tracking code
+# import weakref
+# ROOTS = weakref.WeakSet()
+
 
 class RootTask(ComplexTask):
     """Special task which is always the root of a measurement.
@@ -1086,6 +1090,9 @@ class RootTask(ComplexTask):
     path = Constant('root')
     database_entries = set_default({'default_path': ''})
 
+# HINT: RootTask instance tracking code
+#    __slots__ = ('__weakref__',)
+
     def __init__(self, *args, **kwargs):
         self.preferences = ConfigObj(indent_type='    ', encoding='utf-8')
         self.database = TaskDatabase()
@@ -1095,6 +1102,10 @@ class RootTask(ComplexTask):
         self.parent = self
         self.active_threads_counter.observe('count', self._state)
         self.paused_threads_counter.observe('count', self._state)
+
+# HINT: RootTask instance tracking code
+#        ROOTS.add(self)
+#        print(len(ROOTS))
 
     def check(self, *args, **kwargs):
         """Check that the default path is a valid directory.

--- a/ecpy/tasks/tasks/base_views.enaml
+++ b/ecpy/tasks/tasks/base_views.enaml
@@ -155,11 +155,15 @@ enamldef RootTaskView(BaseTaskView): main:
         """
         try:
             view = _cache.pop(task)
+            # Make sure all children are parented and will hence be properly
+            # destroyed.
+            view.refresh()
+            view.set_parent(None)
             view.destroy()
         except KeyError:
             pass
         else:
-            # Remove all views that may have been destroyed because their
+            # Remove all views that have been destroyed because their
             # parent was just destroyed
             self._cache = {k: v for k, v in _cache.items()
                            if not v.is_destroyed}
@@ -170,9 +174,13 @@ enamldef RootTaskView(BaseTaskView): main:
         # to speed up a bit the process.
         tasks = sorted(_cache, key=attrgetter('depth'))
         for t in tasks:
-            view = _cache[task]
+            view = _cache.pop(t)
             if not view.is_destroyed:
                 view.destroy()
+            # Manually breaking the reference cycles reduce the gc work
+            view.task = None
+            view.root = None
+        self.root = None
 
     constraints = [vbox(hbox(p_lab, p_val, p_exp, prof), editor),
                    align('v_center', p_lab, p_val)]

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,6 @@ sys.path.insert(0, os.path.abspath('.'))
 from ecpy.version import __version__
 
 
-def enaml_build_py(*args, **kwargs):
-    from enaml.build_tools import EnamlBuildPy
-    return EnamlBuildPy(*args, **kwargs)
-
-
-def enaml_install_lib(*args, **kwargs):
-    from enaml.build_tools import EnamlInstallLib
-    return EnamlInstallLib(*args, **kwargs)
-
 setup(
     name='ecpy',
     description='Experiment control application',
@@ -42,13 +33,11 @@ setup(
         ],
     zip_safe=False,
     packages=find_packages(exclude=['tests', 'tests.*']),
-    package_data={'': ['*.txt']},
+    package_data={'': ['*.enaml', '*.txt']},
     requires=['future', 'pyqt', 'atom', 'enaml', 'kiwisolver',
               'configobj', 'watchdog', 'setuptools', 'qtawesome'],
-    setup_requires=['setuptools', 'enaml >= 0.10.2.dev'],
-    install_requires=['setuptools', 'future', 'atom', 'enaml >= 0.10.2.dev',
+    setup_requires=['setuptools'],
+    install_requires=['setuptools', 'future', 'atom', 'enaml',
                       'kiwisolver', 'configobj', 'watchdog', 'qtawesome'],
     entry_points={'gui_scripts': 'ecpy = ecpy.__main__:main'},
-    cmdclass={'build_py': enaml_build_py,
-              'install_lib': enaml_install_lib}
 )

--- a/tests/measure/editors/test_execution_editor.py
+++ b/tests/measure/editors/test_execution_editor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright 2015 by Ecpy Authors, see AUTHORS for more details.
+# Copyright 2015-2017 by Ecpy Authors, see AUTHORS for more details.
 #
 # Distributed under the terms of the BSD license.
 #
@@ -34,6 +34,11 @@ with enaml.imports():
 @pytest.fixture
 def task():
     """Create a basic task hierarchy for testing.
+
+    Root
+      - SimpleTask: parallel=False, wait=False
+      - ComplexTask: parallel=False, wait=True
+        - SimpleTask: parallel=True, wait= False
 
     """
     root = RootTask()
@@ -154,119 +159,158 @@ def test_model_observe_child_adding_removing(task):
     model._child_notifier_observer(notification)
 
 
-def test_execution_editor_widget(windows, task, dialog_sleep):
+def test_execution_editor_widget(windows, task, process_and_sleep):
     """Test the behavior of the execution editor widget.
 
     """
-    dialog_sleep = dialog_sleep or 1
     task.children[1].children[0].parallel = {}
 
     def get_task_widget(editor):
+        """Get the widget associated with the currently selected task.
+
+        """
         return editor.page_widget().widgets()[0].scroll_widget().widgets()[0]
 
     editor = ExecutionEditor(declaration=Editor(id='ecpy.execution_editor'),
                              selected_task=task)
     window = PageTestingWindow(widget=editor)
     window.show()
-    process_app_events()
-    sleep(dialog_sleep)
+    process_and_sleep()
 
+    # Select the complex task (ref ctask)
     ctask = task.children[1]
     editor.selected_task = ctask
-    process_app_events()
-    sleep(dialog_sleep)
+    process_and_sleep()
 
+    # Get the widget (ced) associated with ctask and alter the stoppable
+    # setting and the change propagation
     ced = get_task_widget(editor)
     ced.widgets()[0].checked = not ctask.stoppable
     process_app_events()
     assert ced.widgets()[0].checked == ctask.stoppable
-    sleep(dialog_sleep)
+    process_and_sleep()
 
+    # Ask the editor to hide its children by clicking the button (this does
+    # not check that the layout actually changed simply that is is correct)
+    full_ced = ced.parent
+    full_ced.widgets()[-2].clicked = True
+    assert full_ced.widgets()[-1].visible is False
+    assert not full_ced.widgets()[-1].layout_constraints()
+
+    # Undo
+    full_ced.widgets()[-2].clicked = True
+    assert full_ced.widgets()[-1].visible is True
+    assert full_ced.widgets()[-1].layout_constraints()
+
+    # Set the complex task in parallel and check the update of the list of
+    # pools
     ctask.parallel['pool'] = 'test_'
     ced.widgets()[1].checked = True
-    process_app_events()
+    process_and_sleep()
     assert 'test_' in editor.pool_model.pools
-    sleep(dialog_sleep)
 
+    # Unset the wait setting, change the waiting pool, set the wait and check
+    # the list of pools
     ced.widgets()[3].checked = False
-    process_app_events()
-    sleep(dialog_sleep)
+    process_and_sleep()
     ctask.wait['no_wait'] = ['test2']
     ced.widgets()[3].checked = True
-    process_app_events()
+    process_and_sleep()
     assert 'test2' in editor.pool_model.pools
-    sleep(dialog_sleep)
 
+    # Change the selected pool for parallel and check the list of pools
     ced.widgets()[2].selected = 'test2'
-    process_app_events()
+    process_and_sleep()
     assert 'test' not in editor.pool_model.pools
-    sleep(dialog_sleep)
 
     def get_popup_content(parent):
         return parent.children[-1].central_widget().widgets()
 
+    # Create a new pool using the context menu on parallell
     ced.widgets()[2].children[0].children[0].triggered = True
+    # This can fails on Travis if we do not sleep
     process_app_events()
-    sleep(dialog_sleep)
+    sleep(1)
     process_app_events()  # So that the popup shows correctly
     popup_content = get_popup_content(ced.widgets()[2])
     popup_content[0].text = 'test3'
     popup_content[1].clicked = True
-    process_app_events()
+    process_and_sleep()
     assert 'test3' in editor.pool_model.pools
-    sleep(dialog_sleep)
     process_app_events()  # So that the popup is closed correctly
 
+    # Create a new pool using the context menu on parallell, but cancel it
     ced.widgets()[2].children[0].children[0].triggered = True
+    # This can fails on Travis if we do not sleep
     process_app_events()
-    sleep(dialog_sleep)
+    sleep(1)
     process_app_events()  # So that the popup shows correctly
     popup_content = get_popup_content(ced.widgets()[2])
     popup_content[0].text = 'test4'
     popup_content[2].clicked = True
-    process_app_events()
+    process_and_sleep()
     assert 'test4' not in editor.pool_model.pools
-    sleep(dialog_sleep)
     process_app_events()  # So that the popup is closed correctly
 
-    assert ced.widgets()[4].checked is False
-    ced.widgets()[4].checked = True
-    process_app_events()
+    # Check we were set on no_wait and switch to wait
+    assert ced.widgets()[4].widgets()[0].checked is False
+    ced.widgets()[4].widgets()[0].checked = True
+    process_and_sleep()
     assert 'wait' in ctask.wait and 'no_wait' not in ctask.wait
-    sleep(dialog_sleep)
 
-    ced.widgets()[7].clicked = True
-    process_app_events()
-    sleep(dialog_sleep)
-    popup_content = get_popup_content(ced.widgets()[7])
+    # Use the popup to edit the list of pools on which to wait.
+    # Click ok at the end
+    btt = ced.widgets()[4].widgets()[-1]  # ref to the push button
+    btt.clicked = True
+    process_and_sleep()
+    popup_content = get_popup_content(btt)
     check_box = popup_content[0].scroll_widget().widgets()[1]
     assert not check_box.checked
     check_box.checked = True
-    process_app_events()
-    sleep(dialog_sleep)
+    process_and_sleep()
     popup_content[-2].clicked = True
-    process_app_events()
+    process_and_sleep()
     assert 'test3' in ctask.wait['wait']
-    sleep(dialog_sleep)
 
-    ced.widgets()[7].clicked = True
-    process_app_events()
-    sleep(dialog_sleep)
-    popup_content = get_popup_content(ced.widgets()[7])
+    # Use the popup to edit the list of pools on which to wait.
+    # Click cancel at the end
+    btt.clicked = True
+    process_and_sleep()
+    popup_content = get_popup_content(btt)
     check_box = popup_content[0].scroll_widget().widgets()[2]
     assert not check_box.checked
     check_box.checked = True
-    process_app_events()
-    sleep(dialog_sleep)
+    process_and_sleep()
     popup_content[-1].clicked = True
-    process_app_events()
+    process_and_sleep()
     assert 'test_' not in ctask.wait['wait']
-    sleep(dialog_sleep)
 
+    # Test moving a task and switching between different editors
     editor.selected_task = task
-    task.remove_child_task(1)
-    process_app_events()
+    task.move_child_task(0, 1)
+    process_and_sleep()
+    editor.selected_task = task.children[0]
+    process_and_sleep()
+    editor.selected_task = task.children[1]
+    process_and_sleep()
+    editor.selected_task = task
+
+    # Test removing a task and switching between different editors
+    # First select the ctask child so that its view is not parented to the view
+    editor.selected_task = ctask.children[0]
+
+    # Then select a task that will not reparent it
+    editor.selected_task = task.children[0]
+    task.remove_child_task(0)
+    process_and_sleep()
+    editor.selected_task = task.children[0]
+    process_and_sleep()
+    editor.selected_task = task
+    process_and_sleep()
     assert ctask not in editor._cache
-    sleep(dialog_sleep)
+    # Try removing again this view which should not crash
+    editor.discard_view(task)
+    # Check the view was properly destroyed and removed
+    assert ctask.children[0] not in editor._cache
 
     editor.ended = True

--- a/tests/tasks/tasks/test_base_views.py
+++ b/tests/tasks/tasks/test_base_views.py
@@ -123,10 +123,15 @@ def test_root_view(windows, task_workbench, dialog_sleep):
     sleep(dialog_sleep)
     assert len(view._cache) == 2
 
+    # Test removing the last child and removing a view for an already removed
+    # task
+    child_task = task.children[0]
     editor.operations['remove'](0)
     process_app_events()
     sleep(dialog_sleep)
     assert len(view._cache) == 1
+
+    view.discard_view(child_task)
 
     win.close()
 


### PR DESCRIPTION
This fixes:
- all found bugs in execution editor
- all found bugs in database access editor
- properly remove od measure when loading a new one in an existing dock-item (should fix the last issue when switching workspaces)
- improve cleaning of old tasks/measures. Actually there was a weird reference leak that is now fixed but I still need to add test for this
- more consistent behavior of drag&drop in tree (see commit message for more details)

Todos:
- [x] add tests for the reference leaks in the measure workspace
- [x] improve coverage
- [x] update CHANGES
- [x] cleanup the commits