### PR TITLE
measure: fix argument order in workspace stop functions

### DIFF
--- a/ecpy/measure/workspace/workspace.py
+++ b/ecpy/measure/workspace/workspace.py
@@ -463,13 +463,13 @@ class MeasureSpace(Workspace):
         """Stop the execution of the currently executed measure.
 
         """
-        self.plugin.processor.stop_measure(force, no_post_exec)
+        self.plugin.processor.stop_measure(no_post_exec, force)
 
     def stop_processing_measures(self, no_post_exec=False, force=False):
         """Stop processing enqueued measure.
 
         """
-        self.plugin.processor.stop_processing(force, no_post_exec)
+        self.plugin.processor.stop_processing(no_post_exec, force)
 
     @property
     def dock_area(self):

--- a/tests/measure/workspace/test_workspace.py
+++ b/tests/measure/workspace/test_workspace.py
@@ -543,12 +543,12 @@ def test_measure_execution(workspace):
             self.called = 'resume'
 
         def stop_measure(self, no_post_exec=False, force=False):
-            self.args = dict(no_post_exed=no_post_exec,
+            self.args = dict(no_post_exec=no_post_exec,
                              force=force)
             self.called = 'stop'
 
         def stop_processing(self, no_post_exec=False, force=False):
-            self.args = dict(no_post_exed=no_post_exec,
+            self.args = dict(no_post_exec=no_post_exec,
                              force=force)
             self.called = 'processing'
 

--- a/tests/measure/workspace/test_workspace.py
+++ b/tests/measure/workspace/test_workspace.py
@@ -525,11 +525,13 @@ def test_measure_execution(workspace):
 
     """
     from ecpy.measure.processor import MeasureProcessor
-    from atom.api import Unicode
+    from atom.api import Unicode, Dict
 
     class P(MeasureProcessor):
 
         called = Unicode()
+
+        args = Dict()
 
         def start_measure(self, measure):
             self.called = 'start'
@@ -541,9 +543,13 @@ def test_measure_execution(workspace):
             self.called = 'resume'
 
         def stop_measure(self, no_post_exec=False, force=False):
+            self.args = dict(no_post_exed=no_post_exec,
+                             force=force)
             self.called = 'stop'
 
         def stop_processing(self, no_post_exec=False, force=False):
+            self.args = dict(no_post_exed=no_post_exec,
+                             force=force)
             self.called = 'processing'
 
     workspace.plugin.processor = P()
@@ -585,11 +591,15 @@ def test_measure_execution(workspace):
     workspace.resume_current_measure()
     assert workspace.plugin.processor.called == 'resume'
 
-    workspace.stop_current_measure()
+    workspace.stop_current_measure(no_post_exec=True)
     assert workspace.plugin.processor.called == 'stop'
+    assert workspace.plugin.processor.args == dict(no_post_exec=True,
+                                                   force=False)
 
-    workspace.stop_processing_measures()
+    workspace.stop_processing_measures(force=True)
     assert workspace.plugin.processor.called == 'processing'
+    assert workspace.plugin.processor.args == dict(no_post_exec=False,
+                                                   force=True)
 
 
 def test_remove_processed_measures(workspace):


### PR DESCRIPTION
The bug inverted the no_post_exec and the force argument passed to the processor, causing unwanted forced stops.